### PR TITLE
Use WinAppSDK unpackaged ApplicationData for storage

### DIFF
--- a/WingetGUIInstaller/App.xaml.cs
+++ b/WingetGUIInstaller/App.xaml.cs
@@ -48,7 +48,7 @@ namespace WingetGUIInstaller
 #if UNPACKAGED
 
             _fileStorage = new UnpackagedFileStorageHelper();
-            _settingsStorage = new UnpackagedSettingsStorageHelper(_fileStorage);
+            _settingsStorage = new UnpackagedSettingsStorageHelper();
 #else
 
             _fileStorage = new PackagedFileStorageHelper();

--- a/WingetGUIInstaller/Constants/StorageFolderConstants.cs
+++ b/WingetGUIInstaller/Constants/StorageFolderConstants.cs
@@ -1,9 +1,0 @@
-﻿#if UNPACKAGED
-namespace WingetGUIInstaller.Constants
-{
-    internal static class StorageFolderConstants
-    {
-        public const string ApplicationFolderName = "WingetGuiInstaller";
-    }
-}
-#endif

--- a/WingetGUIInstaller/Constants/UnpackagedApplicationDataConstants.cs
+++ b/WingetGUIInstaller/Constants/UnpackagedApplicationDataConstants.cs
@@ -1,0 +1,10 @@
+#if UNPACKAGED
+namespace WingetGUIInstaller.Constants
+{
+    internal static class UnpackagedApplicationDataConstants
+    {
+        public const string Publisher = "zsolt3991";
+        public const string Product = "WingetGUIInstaller";
+    }
+}
+#endif

--- a/WingetGUIInstaller/Services/LogStorageHelper.cs
+++ b/WingetGUIInstaller/Services/LogStorageHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if UNPACKAGED
+using Microsoft.Windows.Storage;
 using System.Diagnostics;
 #endif
 using System.IO;
@@ -18,8 +19,10 @@ namespace WingetGUIInstaller.Services
         public static string GetLogFileDirectory()
 #if UNPACKAGED
         {
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                StorageFolderConstants.ApplicationFolderName, LoggingConstants.AppLogsFolderName);
+            return Path.Combine(ApplicationData.GetForUnpackaged(
+                    UnpackagedApplicationDataConstants.Publisher,
+                    UnpackagedApplicationDataConstants.Product).LocalPath,
+                LoggingConstants.AppLogsFolderName);
         }
 #else
         {

--- a/WingetGUIInstaller/Services/UnPackagedFileStorageHelper.cs
+++ b/WingetGUIInstaller/Services/UnPackagedFileStorageHelper.cs
@@ -1,5 +1,6 @@
 ﻿#if UNPACKAGED
 using CommunityToolkit.Common.Helpers;
+using Microsoft.Windows.Storage;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,12 +12,25 @@ namespace WingetGUIInstaller.Services
 {
     internal sealed class UnpackagedFileStorageHelper : IFileStorageHelper
     {
-        private readonly string _basePath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        private readonly string _basePath;
+
+        public UnpackagedFileStorageHelper()
+        {
+            _basePath = ApplicationData.GetForUnpackaged(
+                UnpackagedApplicationDataConstants.Publisher,
+                UnpackagedApplicationDataConstants.Product).LocalPath;
+            Directory.CreateDirectory(_basePath);
+        }
 
         public async Task CreateFileAsync<T>(string filePath, T value)
         {
-            var completePath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName, filePath);
+            var completePath = Path.Combine(_basePath, filePath);
             ValidatePath(completePath);
+            var parentDirectory = Path.GetDirectoryName(completePath);
+            if (!string.IsNullOrWhiteSpace(parentDirectory))
+            {
+                Directory.CreateDirectory(parentDirectory);
+            }
 
             var fileContent = JsonSerializer.Serialize<T>(value);
             await File.WriteAllTextAsync(completePath, fileContent);
@@ -24,7 +38,7 @@ namespace WingetGUIInstaller.Services
 
         public Task CreateFolderAsync(string folderPath)
         {
-            var completePath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName, folderPath);
+            var completePath = Path.Combine(_basePath, folderPath);
             ValidatePath(completePath);
 
             Directory.CreateDirectory(completePath);
@@ -33,7 +47,7 @@ namespace WingetGUIInstaller.Services
 
         public async Task<T> ReadFileAsync<T>(string filePath, T defaultValue = default)
         {
-            var completePath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName, filePath);
+            var completePath = Path.Combine(_basePath, filePath);
             ValidatePath(completePath);
 
             if (!File.Exists(completePath))
@@ -56,7 +70,7 @@ namespace WingetGUIInstaller.Services
 
         public Task<IEnumerable<(DirectoryItemType ItemType, string Name)>> ReadFolderAsync(string folderPath)
         {
-            var completePath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName, folderPath);
+            var completePath = Path.Combine(_basePath, folderPath);
             ValidatePath(completePath);
 
             var resultSet = new List<(DirectoryItemType, string)>();
@@ -68,12 +82,12 @@ namespace WingetGUIInstaller.Services
 
             foreach (var subDirectory in Directory.GetDirectories(completePath))
             {
-                resultSet.Add(new(DirectoryItemType.Folder, subDirectory));
+                resultSet.Add(new(DirectoryItemType.Folder, Path.GetFileName(subDirectory)));
             }
 
             foreach (var file in Directory.GetFiles(completePath))
             {
-                resultSet.Add(new(DirectoryItemType.File, file));
+                resultSet.Add(new(DirectoryItemType.File, Path.GetFileName(file)));
             }
 
             return Task.FromResult<IEnumerable<(DirectoryItemType ItemType, string Name)>>(resultSet);
@@ -81,7 +95,7 @@ namespace WingetGUIInstaller.Services
 
         public Task<bool> TryDeleteItemAsync(string itemPath)
         {
-            var completePath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName, itemPath);
+            var completePath = Path.Combine(_basePath, itemPath);
             ValidatePath(completePath);
 
             if (Directory.Exists(completePath))
@@ -91,20 +105,28 @@ namespace WingetGUIInstaller.Services
                     Directory.Delete(completePath);
                     return Task.FromResult(true);
                 }
-                catch
+                catch (IOException)
+                {
+                    return Task.FromResult(false);
+                }
+                catch (UnauthorizedAccessException)
                 {
                     return Task.FromResult(false);
                 }
             }
 
-            if (Directory.Exists(completePath))
+            if (File.Exists(completePath))
             {
                 try
                 {
                     File.Delete(completePath);
                     return Task.FromResult(true);
                 }
-                catch
+                catch (IOException)
+                {
+                    return Task.FromResult(false);
+                }
+                catch (UnauthorizedAccessException)
                 {
                     return Task.FromResult(false);
                 }
@@ -115,8 +137,9 @@ namespace WingetGUIInstaller.Services
 
         public Task<bool> TryRenameItemAsync(string itemPath, string newName)
         {
-            var oldPath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName, itemPath);
-            var newPath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName, newName);
+            var oldPath = Path.Combine(_basePath, itemPath);
+            var parentPath = Path.GetDirectoryName(oldPath) ?? _basePath;
+            var newPath = Path.Combine(parentPath, newName);
             ValidatePath(oldPath);
             ValidatePath(newPath);
 
@@ -127,20 +150,28 @@ namespace WingetGUIInstaller.Services
                     Directory.Move(oldPath, newPath);
                     return Task.FromResult(true);
                 }
-                catch
+                catch (IOException)
+                {
+                    return Task.FromResult(false);
+                }
+                catch (UnauthorizedAccessException)
                 {
                     return Task.FromResult(false);
                 }
             }
 
-            if (Directory.Exists(oldPath))
+            if (File.Exists(oldPath))
             {
                 try
                 {
                     File.Move(oldPath, newPath);
                     return Task.FromResult(true);
                 }
-                catch
+                catch (IOException)
+                {
+                    return Task.FromResult(false);
+                }
+                catch (UnauthorizedAccessException)
                 {
                     return Task.FromResult(false);
                 }
@@ -151,10 +182,10 @@ namespace WingetGUIInstaller.Services
 
         private void ValidatePath(string path)
         {
-            var basePath = Path.Combine(_basePath, StorageFolderConstants.ApplicationFolderName);
+            var basePath = Path.GetFullPath(_basePath);
             var completePath = Path.GetFullPath(path);
 
-            if (!completePath.StartsWith(basePath))
+            if (!completePath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException("Accessing a path outside the application directory is forbidden");
             }

--- a/WingetGUIInstaller/Services/UnpackagedSettingsStorageHelper.cs
+++ b/WingetGUIInstaller/Services/UnpackagedSettingsStorageHelper.cs
@@ -1,97 +1,61 @@
-﻿#if UNPACKAGED
-using CommunityToolkit.Common.Helpers;
+#if UNPACKAGED
 using CommunityToolkit.Helpers;
+using Microsoft.Windows.Storage;
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
+using WingetGUIInstaller.Constants;
 
 namespace WingetGUIInstaller.Services
 {
     internal sealed class UnpackagedSettingsStorageHelper : ISettingsStorageHelper<string>
     {
-        private const string SettingsFileName = "settings.json";
-        private readonly IFileStorageHelper _fileStorage;
-        private readonly SemaphoreSlim _fileAccessSemaphore;
-        private readonly IDictionary<string, string> _settings;
+        private readonly ApplicationDataContainer _container;
 
-        public UnpackagedSettingsStorageHelper(IFileStorageHelper fileStorage)
+        public UnpackagedSettingsStorageHelper()
         {
-            _fileStorage = fileStorage;
-            _settings = _fileStorage.ReadFileAsync(SettingsFileName, new Dictionary<string, string>()).ConfigureAwait(false).GetAwaiter().GetResult();
-            _fileAccessSemaphore = new SemaphoreSlim(1);
+            _container = ApplicationData.GetForUnpackaged(
+                UnpackagedApplicationDataConstants.Publisher,
+                UnpackagedApplicationDataConstants.Product).LocalSettings.CreateContainer(
+                "settings",
+                ApplicationDataCreateDisposition.Always);
         }
 
         public void Clear()
         {
-            if (!_fileStorage.TryDeleteItemAsync(SettingsFileName).GetAwaiter().GetResult())
-            {
-                throw new InvalidOperationException("Failed to clear application settings");
-            }
+            _container.Values.Clear();
         }
 
         public void Save<TValue>(string key, TValue value)
         {
-            if (_settings.ContainsKey(key))
-            {
-                _settings[key] = JsonSerializer.Serialize(value);
-            }
-            else
-            {
-                _settings.TryAdd(key, JsonSerializer.Serialize(value));
-            }
-            SyncSettingsFile();
+            _container.Values[key] = JsonSerializer.Serialize(value);
         }
 
         public bool TryDelete(string key)
         {
-            if (!_settings.ContainsKey(key))
+            if (!_container.Values.ContainsKey(key))
             {
                 return false;
             }
-            _settings.Remove(key);
-            SyncSettingsFile();
+            _container.Values.Remove(key);
             return true;
         }
 
         public bool TryRead<TValue>(string key, out TValue value)
         {
-            if (!_settings.TryGetValue(key, out string serializedValue))
+            if (!_container.Values.TryGetValue(key, out object serializedValue))
             {
                 value = default;
                 return false;
             }
 
-            value = JsonSerializer.Deserialize<TValue>(serializedValue);
-            return true;
-        }
-
-        private void SyncSettingsFile()
-        {
-            Exception syncException = default;
-            ManualResetEvent writeCompleteEvent = new ManualResetEvent(false);
-            _fileAccessSemaphore.Wait();
-
-            Task.Run(async () =>
+            if (serializedValue == default)
             {
-                try
-                {
-                    await _fileStorage.CreateFileAsync(SettingsFileName, _settings);
-                    writeCompleteEvent.Set();
-                }
-                catch (Exception innerException)
-                {
-                    syncException = innerException;
-                }
-            });
-
-            writeCompleteEvent.WaitOne();
-            _fileAccessSemaphore.Release();
-            if (syncException != default)
-            {
-                throw syncException;
+                value = default;
+                return false;
             }
+
+            value = JsonSerializer.Deserialize<TValue>(serializedValue.ToString()!);
+            return true;
         }
     }
 }


### PR DESCRIPTION
﻿## Summary
- switch unpackaged file storage to Microsoft.Windows.Storage.ApplicationData.GetForUnpackaged("zsolt3991", "WingetGUIInstaller")
- switch unpackaged settings storage to LocalSettings in the same ApplicationData store
- switch unpackaged log directory resolution to the same ApplicationData LocalPath
- remove the legacy StorageFolderConstants-based localappdata path

## Notes
- no legacy migration was added by design (no existing users)
- unpackaged Debug build succeeds
