### PR TITLE
chore: add Dependabot config and PR build validation workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "zsolt3991"
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+          - "Microsoft.Win32.*"
+      community-toolkit:
+        patterns:
+          - "CommunityToolkit.*"
+      serilog:
+        patterns:
+          - "Serilog"
+          - "Serilog.*"
+      other-dependencies:
+        patterns:
+          - "CsvHelper"
+          - "Octokit"
+          - "Velopack"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "zsolt3991"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet restore $env:Project_Path -r win-x64
 
       - name: Build
-        run: dotnet build $env:Project_Path --no-restore --configuration Release_Unpackaged -r win-x64 /p:Version=0.0.1
+        run: dotnet publish $env:Project_Path -c Release_Unpackaged -r win-x64 --self-contained /p:Platform=x64 /p:Version=0.0.1
 
   test:
     name: Run Tests

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet restore $env:Project_Path -r win-x64
 
       - name: Build
-        run: dotnet publish $env:Project_Path -c Release_Unpackaged -r win-x64 --self-contained /p:Platform=x64 /p:Version=0.0.1
+        run: dotnet build $env:Project_Path -c Release_Unpackaged -r win-x64 /p:Platform=x64 /p:Version=0.0.1
 
   test:
     name: Run Tests

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -45,10 +45,10 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       - name: Restore dependencies
-        run: dotnet restore $env:Project_Path -r win-x64
+        run: dotnet restore $env:Project_Path -c Release_Unpackaged -r win-x64
 
       - name: Build
-        run: dotnet build $env:Project_Path -c Release_Unpackaged -r win-x64 /p:Platform=x64 /p:Version=0.0.1
+        run: dotnet build $env:Project_Path --no-restore -c Release_Unpackaged -r win-x64 /p:Platform=x64 /p:Version=0.0.1
 
   test:
     name: Run Tests

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       - name: Restore dependencies
-        run: dotnet restore $env:Project_Path -c Release_Unpackaged -r win-x64
+        run: dotnet restore $env:Project_Path -r win-x64
 
       - name: Build
         run: dotnet build $env:Project_Path --no-restore -c Release_Unpackaged -r win-x64 /p:Platform=x64 /p:Version=0.0.1

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,0 +1,71 @@
+name: PR Build Validation
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-wingethelper:
+    name: Build WingetHelper
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore WingetHelper
+
+      - name: Build
+        run: dotnet build WingetHelper --no-restore --configuration Release
+
+  build-wingetguiinstaller:
+    name: Build WingetGUIInstaller
+    runs-on: windows-latest
+
+    env:
+      Project_Path: WingetGUIInstaller/WingetGUIInstaller.csproj
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Restore dependencies
+        run: dotnet restore $env:Project_Path -r win-x64
+
+      - name: Build
+        run: dotnet build $env:Project_Path --no-restore --configuration Release_Unpackaged -r win-x64 /p:Version=0.0.1
+
+  test:
+    name: Run Tests
+    runs-on: windows-latest
+    needs: [build-wingethelper, build-wingetguiinstaller]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Run tests
+        run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Setup MSBuild.exe
-        uses: microsoft/setup-msbuild@v2
-
       - name: Build
         run: dotnet build $env:Project_Path -c Release_Unpackaged -r win-x64 /p:Platform=x64 /p:Version=0.0.1
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -44,11 +44,8 @@ jobs:
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2
 
-      - name: Restore dependencies
-        run: dotnet restore $env:Project_Path -r win-x64
-
       - name: Build
-        run: dotnet build $env:Project_Path --no-restore -c Release_Unpackaged -r win-x64 /p:Platform=x64 /p:Version=0.0.1
+        run: dotnet build $env:Project_Path -c Release_Unpackaged -r win-x64 /p:Platform=x64 /p:Version=0.0.1
 
   test:
     name: Run Tests


### PR DESCRIPTION
## Summary

### Dependabot (`dependabot.yml`)
- Weekly updates for **NuGet** and **GitHub Actions** ecosystems
- PRs grouped by package family to reduce noise:
  - `microsoft-extensions` — `Microsoft.Extensions.*`, `Microsoft.Win32.*`
  - `community-toolkit` — all `CommunityToolkit.*` packages
  - `serilog` — `Serilog` and all sinks/extensions
  - `other-dependencies` — `CsvHelper`, `Octokit`, `Velopack`
- `Microsoft.WindowsAppSDK` and `Microsoft.Windows.SDK.BuildTools.MSIX` get **solo PRs** due to known build sensitivity
- Commit prefix `chore`, label `dependencies`, reviewer `zsolt3991`

### PR Build Workflow (`pr_build.yml`)
- Triggers on all PRs targeting `master`
- Two parallel build jobs:
  - **WingetHelper** — `ubuntu-latest`, `dotnet build`
  - **WingetGUIInstaller** — `windows-latest`, MSBuild + `Release_Unpackaged` config
- **Test job** stub runs after both builds pass — automatically picks up any test projects added in the future