### PR TITLE
Fix release publish asset glob patterns

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -269,6 +269,5 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/nuget-packages/*.nupkg
-            artifacts/packaged-msix-*/*.msixbundle
-            artifacts/velopack-*/*
-            artifacts/velopack-*/**
+            artifacts/packaged-msix-*/**/*.msixbundle
+            artifacts/velopack-*/**/*


### PR DESCRIPTION
## Summary
- fix Publish GitHub release file globs to avoid duplicate Velopack uploads
- make packaged artifact glob recursive so downloaded artifact layout is matched reliably

## Why
The previous patterns uploaded the same Velopack assets multiple times (due to overlapping globs), which caused softprops/action-gh-release to fail while updating asset metadata.